### PR TITLE
Privacy: mask custom RTMP URL in settings UI

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -503,9 +503,7 @@ const DeckyStreamer: VFC<{ serverAPI: ServerAPI, logic: DeckyStreamerLogic }> = 
                   });
                 }}
               >
-                {customRtmpUrl 
-                  ? (customRtmpUrl.length > 30 ? customRtmpUrl.slice(0, 30) + "..." : customRtmpUrl)
-                  : "Tap to enter RTMP URL..."}
+                {customRtmpUrl ? "••••••••••••" : "Tap to enter RTMP URL..."}
               </ButtonItem>
             </PanelSectionRow>
             <PanelSectionRow>


### PR DESCRIPTION
## Summary
- mask the displayed value of the custom RTMP URL in Decky Streamer settings
- keep the existing value/edit flow unchanged (tap to edit still works)

## Why this is necessary
When users open Quick Access ("...") while streaming, the plugin UI can be visible on stream. The custom RTMP URL was rendered in plain text, which can expose private/self-hosted relay endpoints and infrastructure details.

This change aligns URL privacy with the existing Stream Key behavior by showing bullets instead of the raw value, reducing accidental credential/endpoint disclosure during live streams.

## Scope
- UI-only change in `src/index.tsx`
- no backend or pipeline behavior changes